### PR TITLE
Fix edge ontology properties display and saving

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -607,3 +607,224 @@
 .download-button:hover {
   background-color: #218838;
 }
+
+/* Ontology Panel Styles */
+.ontology-panel {
+  width: 300px;
+  background-color: #f8f9fa;
+  border-left: 1px solid #e9ecef;
+  overflow-y: auto;
+  padding: 15px;
+  height: 100%;
+}
+
+.entity-form, .property-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+
+.entity-form input, .property-form input, .property-form select {
+  padding: 8px;
+  border: 1px solid #ced4da;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.entity-form-buttons, .property-form-buttons {
+  display: flex;
+  gap: 10px;
+}
+
+.add-button, .save-button, .cancel-button {
+  padding: 8px 15px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.add-button {
+  background-color: #007bff;
+  color: white;
+}
+
+.add-button:hover {
+  background-color: #0069d9;
+}
+
+.save-button {
+  background-color: #28a745;
+  color: white;
+}
+
+.save-button:hover {
+  background-color: #218838;
+}
+
+.cancel-button {
+  background-color: #6c757d;
+  color: white;
+}
+
+.cancel-button:hover {
+  background-color: #5a6268;
+}
+
+.entity-list, .property-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 15px;
+}
+
+.entity-item, .property-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px;
+  background-color: white;
+  border: 1px solid #e9ecef;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.entity-item:hover {
+  background-color: #f1f3f5;
+}
+
+.entity-item.selected {
+  background-color: #e3f2fd;
+  border-color: #90caf9;
+}
+
+.entity-actions, .property-actions {
+  display: flex;
+  gap: 5px;
+}
+
+.edit-button, .delete-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+}
+
+.edit-button {
+  color: #6c757d;
+}
+
+.edit-button:hover {
+  color: #495057;
+  background-color: #e9ecef;
+}
+
+.delete-button {
+  color: #dc3545;
+}
+
+.delete-button:hover {
+  color: #c82333;
+  background-color: #f8d7da;
+}
+
+.property-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.property-name {
+  font-weight: bold;
+  color: #495057;
+}
+
+.property-type {
+  font-size: 12px;
+  color: #6c757d;
+}
+
+/* Edge Properties Styles */
+.edge-properties {
+  position: absolute;
+  top: 70px;
+  right: 320px; /* Position next to the ontology panel */
+  width: 300px;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  padding: 15px;
+  z-index: 100;
+  max-height: calc(100vh - 100px);
+  overflow-y: auto;
+}
+
+.edge-type-badge {
+  display: inline-block;
+  background-color: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 4px;
+  padding: 5px 10px;
+  font-size: 12px;
+  color: #495057;
+  margin-top: 5px;
+  margin-right: 5px;
+}
+
+.entity-properties-list {
+  margin-top: 10px;
+}
+
+.entity-property-item {
+  display: flex;
+  flex-direction: column;
+  padding: 8px 0;
+  border-bottom: 1px solid #eee;
+}
+
+.property-name {
+  font-weight: 500;
+  margin-bottom: 5px;
+}
+
+.property-type {
+  color: #666;
+  font-size: 0.8rem;
+  margin-left: 5px;
+}
+
+.entity-property-item input,
+.entity-property-item select {
+  padding: 6px 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  margin-bottom: 5px;
+  width: 100%;
+}
+
+.entity-properties-list {
+  margin-top: 10px;
+}
+
+.entity-property-item {
+  display: flex;
+  justify-content: space-between;
+  padding: 5px 10px;
+  background-color: #f8f9fa;
+  border-radius: 4px;
+  margin-bottom: 5px;
+}
+
+.no-properties {
+  font-style: italic;
+  color: #6c757d;
+  font-size: 12px;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import ReactFlow, {
   useEdgesState,
   addEdge,
   Panel,
+  MarkerType,
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 import './App.css';
@@ -19,6 +20,8 @@ import NodeToolbar from './components/NodeToolbar';
 import LeftPanel from './components/LeftPanel';
 import ExportButton from './components/ExportButton';
 import NodeProperties from './components/NodeProperties';
+import EdgeProperties from './components/EdgeProperties';
+import OntologyPanel from './components/OntologyPanel';
 
 // Initial nodes and edges
 const initialNodes = [
@@ -58,20 +61,124 @@ function App() {
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
   const [selectedNode, setSelectedNode] = useState(null);
+  const [selectedEdge, setSelectedEdge] = useState(null);
   const [reactFlowInstance, setReactFlowInstance] = useState(null);
+  // Initialize ontology with some example entities if needed
+  const [ontology, setOntology] = useState({ 
+    entities: [
+      {
+        id: 'entity_default_1',
+        name: 'Relationship',
+        properties: [
+          { id: 'prop_1', name: 'Type', type: 'string' },
+          { id: 'prop_2', name: 'Strength', type: 'number' }
+        ]
+      },
+      {
+        id: 'entity_default_2',
+        name: 'Dependency',
+        properties: [
+          { id: 'prop_3', name: 'Direction', type: 'string' },
+          { id: 'prop_4', name: 'Required', type: 'boolean' }
+        ]
+      }
+    ] 
+  });
+  
+  // Debug ontology state
+  console.log('Initial ontology state:', ontology);
   const reactFlowWrapper = useRef(null);
   const exportButtonRef = useRef(null);
 
   // Handle connections between nodes
   const onConnect = useCallback(
-    (params) => setEdges((eds) => addEdge(params, eds)),
+    (params) => {
+      console.log('Creating new connection with params:', params);
+      const newEdge = {
+        ...params,
+        type: 'default',
+        animated: false,
+        style: { stroke: '#555' },
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+          color: '#555',
+        },
+        data: {
+          label: '',
+          entityId: '',
+          description: ''
+        },
+        label: '' // Add label at the edge level for display
+      };
+      console.log('Created new edge:', newEdge);
+      const result = setEdges((eds) => addEdge(newEdge, eds));
+      return result;
+    },
     [setEdges]
   );
 
   // Handle node selection
   const onNodeClick = useCallback((event, node) => {
     setSelectedNode(node);
+    setSelectedEdge(null); // Clear edge selection when a node is clicked
   }, []);
+  
+  // Handle edge selection
+  const onEdgeClick = useCallback((event, edge) => {
+    setSelectedEdge(edge);
+    setSelectedNode(null); // Clear node selection when an edge is clicked
+  }, []);
+  
+  // Close node properties panel
+  const closeNodeProperties = useCallback(() => {
+    setSelectedNode(null);
+  }, []);
+  
+  // Close edge properties panel
+  const closeEdgeProperties = useCallback(() => {
+    setSelectedEdge(null);
+  }, []);
+  
+  // Update edge data
+  const updateEdgeData = useCallback((edgeId, newData) => {
+    console.log('Updating edge with ID:', edgeId);
+    console.log('New edge data:', newData);
+    
+    setEdges((eds) => {
+      const updatedEdges = eds.map((edge) => {
+        if (edge.id === edgeId) {
+          const updatedEdge = {
+            ...edge,
+            data: {
+              ...edge.data,
+              ...newData
+            },
+            label: newData.label || '',
+            // Update edge styling based on entity selection
+            animated: newData.entityId ? true : false,
+            style: { 
+              stroke: newData.entityId ? '#007bff' : '#555',
+              strokeWidth: newData.entityId ? 2 : 1
+            }
+          };
+          console.log('Updated edge:', updatedEdge);
+          return updatedEdge;
+        }
+        return edge;
+      });
+      
+      console.log('All updated edges:', updatedEdges);
+      return updatedEdges;
+    });
+  }, [setEdges]);
+  
+  // Delete edge
+  const deleteEdge = useCallback((edgeId) => {
+    setEdges((eds) => eds.filter((edge) => edge.id !== edgeId));
+    setSelectedEdge(null);
+  }, [setEdges]);
 
   // Add new node to the canvas
   const onAddNode = useCallback(
@@ -180,6 +287,7 @@ function App() {
             onEdgesChange={onEdgesChange}
             onConnect={onConnect}
             onNodeClick={onNodeClick}
+            onEdgeClick={onEdgeClick}
             nodeTypes={nodeTypes}
             onInit={setReactFlowInstance}
             onDrop={onDrop}
@@ -196,7 +304,9 @@ function App() {
                 saveLoadProps={{
                   reactFlowInstance,
                   setNodes,
-                  setEdges
+                  setEdges,
+                  ontology,
+                  setOntology
                 }}
                 exportProps={{
                   handleExport: () => {
@@ -221,10 +331,25 @@ function App() {
           <NodeProperties 
             selectedNode={selectedNode}
             onUpdateNodeData={onUpdateNodeData}
-            onClose={() => setSelectedNode(null)}
+            onClose={closeNodeProperties}
             onDeleteNode={onDeleteNode}
           />
         )}
+        
+        {selectedEdge && (
+          <EdgeProperties 
+            selectedEdge={selectedEdge}
+            onUpdateEdgeData={updateEdgeData}
+            onClose={closeEdgeProperties}
+            onDeleteEdge={deleteEdge}
+            ontology={ontology}
+          />
+        )}
+        
+        <OntologyPanel 
+          ontology={ontology} 
+          setOntology={setOntology} 
+        />
       </div>
     </div>
   );

--- a/src/components/EdgeProperties.js
+++ b/src/components/EdgeProperties.js
@@ -1,0 +1,174 @@
+import React, { useState, useEffect } from 'react';
+import { FaTimes, FaTrash, FaSave } from 'react-icons/fa';
+
+const EdgeProperties = ({ selectedEdge, onUpdateEdgeData, onClose, onDeleteEdge, ontology }) => {
+  const [edgeData, setEdgeData] = useState({
+    label: selectedEdge?.data?.label || '',
+    entityId: selectedEdge?.data?.entityId || '',
+    description: selectedEdge?.data?.description || '',
+    properties: selectedEdge?.data?.properties || {}
+  });
+
+  // Update local state when selected edge changes
+  useEffect(() => {
+    if (selectedEdge) {
+      console.log('Selected edge data:', selectedEdge.data);
+      setEdgeData({
+        label: selectedEdge.data?.label || '',
+        entityId: selectedEdge.data?.entityId || '',
+        description: selectedEdge.data?.description || '',
+        properties: selectedEdge.data?.properties || {}
+      });
+    }
+  }, [selectedEdge]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setEdgeData({
+      ...edgeData,
+      [name]: value
+    });
+  };
+  
+  // Handle property value changes
+  const handlePropertyChange = (propId, value) => {
+    setEdgeData({
+      ...edgeData,
+      properties: {
+        ...edgeData.properties,
+        [propId]: value
+      }
+    });
+  };
+
+  const handleSave = () => {
+    console.log('Saving edge data:', edgeData);
+    onUpdateEdgeData(selectedEdge.id, edgeData);
+  };
+
+  const handleDelete = () => {
+    onDeleteEdge(selectedEdge.id);
+  };
+
+  // Find the selected entity
+  const selectedEntity = ontology?.entities?.find(entity => entity.id === edgeData.entityId);
+  
+  // Debug ontology data
+  console.log('Ontology in EdgeProperties:', ontology);
+  console.log('Selected Entity ID:', edgeData.entityId);
+  console.log('Selected Entity:', selectedEntity);
+
+  return (
+    <div className="edge-properties">
+      <div className="properties-header">
+        <h3>Edge Properties</h3>
+        <button className="close-properties-button" onClick={onClose}>
+          <FaTimes />
+        </button>
+      </div>
+
+      <div className="property">
+        <label>Label</label>
+        <input
+          type="text"
+          name="label"
+          value={edgeData.label || ''}
+          onChange={handleChange}
+          placeholder="Edge Label"
+        />
+      </div>
+
+      <div className="property">
+        <label>Entity</label>
+        <select
+          name="entityId"
+          value={edgeData.entityId || ''}
+          onChange={handleChange}
+        >
+          <option value="">-- Select Entity --</option>
+          {ontology?.entities?.map(entity => (
+            <option key={entity.id} value={entity.id}>
+              {entity.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {selectedEntity && (
+        <div className="property-section">
+          <h4>Entity Properties</h4>
+          <div className="entity-properties-list">
+            {selectedEntity.properties.map(prop => (
+              <div key={prop.id} className="entity-property-item">
+                <label className="property-name">{prop.name}</label>
+                {prop.type === 'string' && (
+                  <input
+                    type="text"
+                    value={edgeData.properties[prop.id] || ''}
+                    onChange={(e) => handlePropertyChange(prop.id, e.target.value)}
+                    placeholder={`Enter ${prop.name}`}
+                  />
+                )}
+                {prop.type === 'number' && (
+                  <input
+                    type="number"
+                    value={edgeData.properties[prop.id] || ''}
+                    onChange={(e) => handlePropertyChange(prop.id, e.target.value)}
+                    placeholder={`Enter ${prop.name}`}
+                  />
+                )}
+                {prop.type === 'boolean' && (
+                  <select
+                    value={edgeData.properties[prop.id] || ''}
+                    onChange={(e) => handlePropertyChange(prop.id, e.target.value)}
+                  >
+                    <option value="">-- Select --</option>
+                    <option value="true">True</option>
+                    <option value="false">False</option>
+                  </select>
+                )}
+                <span className="property-type">({prop.type})</span>
+              </div>
+            ))}
+            {selectedEntity.properties.length === 0 && (
+              <p className="no-properties">No properties defined for this entity</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className="property">
+        <label>Description</label>
+        <textarea
+          name="description"
+          value={edgeData.description || ''}
+          onChange={handleChange}
+          placeholder="Edge Description"
+        />
+      </div>
+
+      <div className="edge-type-badge">
+        Edge ID: {selectedEdge.id}
+      </div>
+
+      <div className="edge-type-badge">
+        Source: {selectedEdge.source}
+      </div>
+
+      <div className="edge-type-badge">
+        Target: {selectedEdge.target}
+      </div>
+
+      <div className="property-buttons">
+        <button className="delete-button" onClick={handleDelete}>
+          <FaTrash /> Delete
+        </button>
+        <button className="save-properties-button" onClick={handleSave}>
+          <FaSave /> Save
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default EdgeProperties;

--- a/src/components/NodeToolbar.js
+++ b/src/components/NodeToolbar.js
@@ -1,56 +1,9 @@
 import React from 'react';
-import { FaDatabase, FaCogs, FaFileExport, FaSave, FaUpload, FaFileCode } from 'react-icons/fa';
+import { FaDatabase, FaCogs, FaFileExport, FaFileCode } from 'react-icons/fa';
+import SaveLoadButtons from './SaveLoadButtons';
 
 const NodeToolbar = ({ onAddNode, saveLoadProps, exportProps }) => {
-  const { reactFlowInstance, setNodes, setEdges } = saveLoadProps || {};
-  
-  // Save workflow to JSON
-  const saveWorkflow = () => {
-    if (reactFlowInstance) {
-      const flow = reactFlowInstance.toObject();
-      const json = JSON.stringify(flow, null, 2);
-      
-      // Create a blob and download link
-      const blob = new Blob([json], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = 'pnc-metamodel-workflow.json';
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    }
-  };
-  
-  // Load workflow from file
-  const loadWorkflow = (event) => {
-    const fileReader = new FileReader();
-    fileReader.onload = (e) => {
-      try {
-        const flow = JSON.parse(e.target.result);
-        
-        if (flow && flow.nodes && flow.edges && reactFlowInstance) {
-          // Clear current flow
-          setNodes([]);
-          setEdges([]);
-          
-          // Set viewport
-          reactFlowInstance.setViewport(flow.viewport || { x: 0, y: 0, zoom: 1 });
-          
-          // Add nodes and edges
-          setNodes(flow.nodes || []);
-          setEdges(flow.edges || []);
-        }
-      } catch (error) {
-        console.error('Error loading workflow:', error);
-        alert('Failed to load workflow. Invalid file format.');
-      }
-    };
-    
-    if (event.target.files && event.target.files.length > 0) {
-      fileReader.readAsText(event.target.files[0]);
-    }
-  };
+  const { reactFlowInstance, setNodes, setEdges, ontology, setOntology } = saveLoadProps || {};
 
   // Export to AsyncAPI
   const handleExport = () => {
@@ -73,21 +26,13 @@ const NodeToolbar = ({ onAddNode, saveLoadProps, exportProps }) => {
       
       <div className="toolbar-divider"></div>
       
-      <button className="action-button save-button" onClick={saveWorkflow} title="Save Workflow">
-        <FaSave className="button-icon" />
-        <span className="button-text">Save</span>
-      </button>
-      
-      <label className="action-button load-button" title="Load Workflow">
-        <FaUpload className="button-icon" />
-        <span className="button-text">Load</span>
-        <input 
-          type="file" 
-          accept=".json" 
-          style={{ display: 'none' }} 
-          onChange={loadWorkflow} 
-        />
-      </label>
+      <SaveLoadButtons 
+        reactFlowInstance={reactFlowInstance}
+        setNodes={setNodes}
+        setEdges={setEdges}
+        ontology={ontology}
+        setOntology={setOntology}
+      />
       
       <button className="action-button export-button" onClick={handleExport} title="Export as AsyncAPI">
         <FaFileCode className="button-icon" />

--- a/src/components/OntologyPanel.js
+++ b/src/components/OntologyPanel.js
@@ -1,0 +1,259 @@
+import React, { useState, useEffect } from 'react';
+import { FaPlus, FaTrash, FaEdit, FaSave } from 'react-icons/fa';
+import { MdOutlineCategory } from 'react-icons/md';
+
+const OntologyPanel = ({ ontology, setOntology }) => {
+  const [entities, setEntities] = useState(ontology?.entities || []);
+  const [newEntityName, setNewEntityName] = useState('');
+  const [newPropertyName, setNewPropertyName] = useState('');
+  const [newPropertyType, setNewPropertyType] = useState('string');
+  const [selectedEntity, setSelectedEntity] = useState(null);
+  const [editMode, setEditMode] = useState(false);
+  const [editItem, setEditItem] = useState(null);
+
+  useEffect(() => {
+    if (ontology?.entities) {
+      setEntities(ontology.entities);
+    }
+  }, [ontology]);
+
+  useEffect(() => {
+    setOntology({ ...ontology, entities });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entities]);
+
+  const addEntity = () => {
+    if (newEntityName.trim() === '') return;
+    
+    if (editMode && editItem) {
+      // Update existing entity
+      setEntities(entities.map(entity => 
+        entity.id === editItem.id 
+          ? { ...entity, name: newEntityName } 
+          : entity
+      ));
+      setEditMode(false);
+      setEditItem(null);
+    } else {
+      // Add new entity
+      const newEntity = {
+        id: `entity_${Date.now()}`,
+        name: newEntityName,
+        properties: []
+      };
+      setEntities([...entities, newEntity]);
+    }
+    
+    setNewEntityName('');
+  };
+
+  const deleteEntity = (entityId) => {
+    setEntities(entities.filter(entity => entity.id !== entityId));
+    if (selectedEntity?.id === entityId) {
+      setSelectedEntity(null);
+    }
+  };
+
+  const editEntity = (entity) => {
+    setNewEntityName(entity.name);
+    setEditMode(true);
+    setEditItem(entity);
+  };
+
+  const addProperty = () => {
+    if (!selectedEntity || newPropertyName.trim() === '') return;
+    
+    if (editMode && editItem) {
+      // Update existing property
+      const updatedEntities = entities.map(entity => {
+        if (entity.id === selectedEntity.id) {
+          const updatedProperties = entity.properties.map(prop => 
+            prop.id === editItem.id 
+              ? { ...prop, name: newPropertyName, type: newPropertyType } 
+              : prop
+          );
+          return { ...entity, properties: updatedProperties };
+        }
+        return entity;
+      });
+      setEntities(updatedEntities);
+      setEditMode(false);
+      setEditItem(null);
+    } else {
+      // Add new property
+      const newProperty = {
+        id: `prop_${Date.now()}`,
+        name: newPropertyName,
+        type: newPropertyType
+      };
+      
+      const updatedEntities = entities.map(entity => {
+        if (entity.id === selectedEntity.id) {
+          return {
+            ...entity,
+            properties: [...entity.properties, newProperty]
+          };
+        }
+        return entity;
+      });
+      
+      setEntities(updatedEntities);
+    }
+    
+    setNewPropertyName('');
+    setNewPropertyType('string');
+  };
+
+  const deleteProperty = (propertyId) => {
+    const updatedEntities = entities.map(entity => {
+      if (entity.id === selectedEntity.id) {
+        return {
+          ...entity,
+          properties: entity.properties.filter(prop => prop.id !== propertyId)
+        };
+      }
+      return entity;
+    });
+    
+    setEntities(updatedEntities);
+  };
+
+  const editProperty = (property) => {
+    setNewPropertyName(property.name);
+    setNewPropertyType(property.type);
+    setEditMode(true);
+    setEditItem(property);
+  };
+
+  const cancelEdit = () => {
+    setEditMode(false);
+    setEditItem(null);
+    setNewEntityName('');
+    setNewPropertyName('');
+    setNewPropertyType('string');
+  };
+
+  return (
+    <div className="ontology-panel">
+      <div className="panel-header">
+        <h3><MdOutlineCategory className="panel-header-icon" /> Ontology</h3>
+      </div>
+      
+      <div className="panel-section">
+        <h4>Entities</h4>
+        <div className="entity-form">
+          <input
+            type="text"
+            placeholder="Entity name"
+            value={newEntityName}
+            onChange={(e) => setNewEntityName(e.target.value)}
+          />
+          <div className="entity-form-buttons">
+            {editMode ? (
+              <>
+                <button className="save-button" onClick={addEntity}>
+                  <FaSave /> Update
+                </button>
+                <button className="cancel-button" onClick={cancelEdit}>
+                  Cancel
+                </button>
+              </>
+            ) : (
+              <button className="add-button" onClick={addEntity}>
+                <FaPlus /> Add Entity
+              </button>
+            )}
+          </div>
+        </div>
+        
+        <div className="entity-list">
+          {entities.map(entity => (
+            <div 
+              key={entity.id} 
+              className={`entity-item ${selectedEntity?.id === entity.id ? 'selected' : ''}`}
+              onClick={() => setSelectedEntity(entity)}
+            >
+              <div className="entity-name">{entity.name}</div>
+              <div className="entity-actions">
+                <button className="edit-button" onClick={(e) => {
+                  e.stopPropagation();
+                  editEntity(entity);
+                }}>
+                  <FaEdit />
+                </button>
+                <button className="delete-button" onClick={(e) => {
+                  e.stopPropagation();
+                  deleteEntity(entity.id);
+                }}>
+                  <FaTrash />
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      
+      {selectedEntity && (
+        <div className="panel-section">
+          <h4>Properties for {selectedEntity.name}</h4>
+          <div className="property-form">
+            <input
+              type="text"
+              placeholder="Property name"
+              value={newPropertyName}
+              onChange={(e) => setNewPropertyName(e.target.value)}
+            />
+            <select
+              value={newPropertyType}
+              onChange={(e) => setNewPropertyType(e.target.value)}
+            >
+              <option value="string">String</option>
+              <option value="number">Number</option>
+              <option value="boolean">Boolean</option>
+              <option value="date">Date</option>
+              <option value="object">Object</option>
+              <option value="array">Array</option>
+            </select>
+            <div className="property-form-buttons">
+              {editMode ? (
+                <>
+                  <button className="save-button" onClick={addProperty}>
+                    <FaSave /> Update
+                  </button>
+                  <button className="cancel-button" onClick={cancelEdit}>
+                    Cancel
+                  </button>
+                </>
+              ) : (
+                <button className="add-button" onClick={addProperty}>
+                  <FaPlus /> Add Property
+                </button>
+              )}
+            </div>
+          </div>
+          
+          <div className="property-list">
+            {selectedEntity.properties.map(property => (
+              <div key={property.id} className="property-item">
+                <div className="property-info">
+                  <span className="property-name">{property.name}</span>
+                  <span className="property-type">{property.type}</span>
+                </div>
+                <div className="property-actions">
+                  <button className="edit-button" onClick={() => editProperty(property)}>
+                    <FaEdit />
+                  </button>
+                  <button className="delete-button" onClick={() => deleteProperty(property.id)}>
+                    <FaTrash />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default OntologyPanel;

--- a/src/components/SaveLoadButtons.js
+++ b/src/components/SaveLoadButtons.js
@@ -1,12 +1,19 @@
 import React, { useCallback } from 'react';
 import { FaSave, FaUpload } from 'react-icons/fa';
 
-const SaveLoadButtons = ({ reactFlowInstance, setNodes, setEdges }) => {
+const SaveLoadButtons = ({ reactFlowInstance, setNodes, setEdges, ontology, setOntology }) => {
   // Save workflow to JSON
   const saveWorkflow = useCallback(() => {
     if (reactFlowInstance) {
       const flow = reactFlowInstance.toObject();
-      const json = JSON.stringify(flow, null, 2);
+      
+      // Add ontology data to the flow object
+      const flowWithOntology = {
+        ...flow,
+        ontology: ontology
+      };
+      
+      const json = JSON.stringify(flowWithOntology, null, 2);
       
       // Create a blob and download link
       const blob = new Blob([json], { type: 'application/json' });
@@ -18,7 +25,7 @@ const SaveLoadButtons = ({ reactFlowInstance, setNodes, setEdges }) => {
       link.click();
       document.body.removeChild(link);
     }
-  }, [reactFlowInstance]);
+  }, [reactFlowInstance, ontology]);
   
   // Load workflow from file
   const loadWorkflow = useCallback((event) => {
@@ -38,6 +45,11 @@ const SaveLoadButtons = ({ reactFlowInstance, setNodes, setEdges }) => {
           // Add nodes and edges
           setNodes(flow.nodes || []);
           setEdges(flow.edges || []);
+          
+          // Load ontology data if available
+          if (flow.ontology) {
+            setOntology(flow.ontology);
+          }
         }
       } catch (error) {
         console.error('Error loading workflow:', error);
@@ -48,7 +60,7 @@ const SaveLoadButtons = ({ reactFlowInstance, setNodes, setEdges }) => {
     if (event.target.files && event.target.files.length > 0) {
       fileReader.readAsText(event.target.files[0]);
     }
-  }, [reactFlowInstance, setNodes, setEdges]);
+  }, [reactFlowInstance, setNodes, setEdges, setOntology]);
 
   return (
     <div className="save-load-buttons">


### PR DESCRIPTION
## Description
This PR fixes the issue with ontology properties not being displayed or saved for edge connections between nodes.

## Changes
- Added support for entity properties in the EdgeProperties component
- Added a handlePropertyChange function to update entity property values
- Updated the UI to display entity properties with appropriate input fields based on property type
- Added CSS styles for entity properties
- Fixed edge data initialization in EdgeProperties component
- Added properties field to edgeData state

## Testing
Tested by creating edges between nodes and verifying that:
- Entity properties are displayed in the edge properties panel
- Property values can be edited and saved
- Property values persist when the edge is selected again